### PR TITLE
Fix Unreal startup crash when Vdb Actors exist on startup map

### DIFF
--- a/Source/Runtime/Private/Rendering/VdbMaterialRendering.cpp
+++ b/Source/Runtime/Private/Rendering/VdbMaterialRendering.cpp
@@ -560,9 +560,10 @@ void FVdbMaterialRendering::BeginRenderViewFamily(FSceneViewFamily& InViewFamily
 		if (const FRenderTarget* RefRenderTarget = InViewFamily.RenderTarget)
 		{
 			const FSceneTexturesConfig& Config = FSceneTexturesConfig::Get();
-			if (Config.Extent.X != DefaultVdbRenderTarget->SizeX ||
+			if ((Config.Extent.X != DefaultVdbRenderTarget->SizeX ||
 				Config.Extent.Y != DefaultVdbRenderTarget->SizeY ||
-				DefaultVdbRenderTarget->RenderTargetFormat != RTF_RGBA16f)
+				DefaultVdbRenderTarget->RenderTargetFormat != RTF_RGBA16f) &&
+				(Config.Extent.X > 0 && Config.Extent.Y > 0))
 			{
 				DefaultVdbRenderTarget->ClearColor = FLinearColor::Transparent;
 				DefaultVdbRenderTarget->InitCustomFormat(Config.Extent.X, Config.Extent.Y, PF_FloatRGBA, true);

--- a/Source/Runtime/Private/Rendering/VdbPrincipledRendering.cpp
+++ b/Source/Runtime/Private/Rendering/VdbPrincipledRendering.cpp
@@ -434,9 +434,10 @@ void FVdbPrincipledRendering::BeginRenderViewFamily(FSceneViewFamily& InViewFami
 		if (const FRenderTarget* RefRenderTarget = InViewFamily.RenderTarget)
 		{
 			const FSceneTexturesConfig& Config = FSceneTexturesConfig::Get();
-			if (Config.Extent.X != DefaultVdbRenderTarget->SizeX ||
-				Config.Extent.Y != DefaultVdbRenderTarget->SizeY ||
-				DefaultVdbRenderTarget->RenderTargetFormat != RTF_RGBA16f)
+			if ((Config.Extent.X != DefaultVdbRenderTarget->SizeX ||
+				Config.Extent.Y != DefaultVdbRenderTarget->SizeY || 
+				DefaultVdbRenderTarget->RenderTargetFormat != RTF_RGBA16f) &&
+				(Config.Extent.X > 0 && Config.Extent.Y > 0))
 			{
 				DefaultVdbRenderTarget->ClearColor = FLinearColor::Transparent;
 				DefaultVdbRenderTarget->InitCustomFormat(Config.Extent.X, Config.Extent.Y, PF_FloatRGBA, true);


### PR DESCRIPTION
BeginRenderViewFamily gets called before FSceneTexturesConfig's extends are set.
This fix makes sure that the extends are above 0 so the RenderTarget can Initialize correctly